### PR TITLE
DjangoQuilla -> Python Barranquilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # codigo-de-conducta
-Este repositorio contiene el código de conducta de la comunidad de [Django Barranquilla.](http://djangoquilla.com/)
+Este repositorio contiene el código de conducta de la comunidad de [Python Barranquilla.](http://pybaq.co/)
 
-## Código de Conducta de Django
+## Código de Conducta de Python Barranquilla
 
-Como la comunidad técnica en general, el equipo de Django y su comunidad están hechos de una mezcla de profesionales y voluntarios de todas partes del mundo, que trabajan en cada aspecto de la misión - incluso mentorías, enseñanza y conectando personas.
+Como la comunidad técnica en general, el equipo de Python Barranquilla y su comunidad están hechos de una mezcla de profesionales y voluntarios de todas partes del mundo, que trabajan en cada aspecto de la misión - incluso mentorías, enseñanza y conectando personas.
 
 La diversidad es una de nuestras mas grandes fortalezas, pero tambien puede llevar a problemas de comunicación e infelicidad. Para tal propósito, tenemos algunas reglas básicas a las cuales solicitamos que las personas se adhieran. Este código aplica igualmente a los fundadores, mentores y aquellos buscando ayuda y guía.
 
@@ -11,7 +11,7 @@ Esta no es una lista exhaustiva de las cosas que no puedes hacer. Mas bien, tóm
 
 Este código de conducta aplica a todos los espacios administrados por el proyecto Django Barranquilla. Esto incluye IRC, las listas de correos, el software de seguimiento, eventos y otros foros creados por el equipo del proyecto los cuales la comunidad usa para comunicación. Adicionalmente, violaciones a este código fuera de estos espacios puede afectar la habilidad de la persona de participar en ellos.
 
-Si cree que alguien está violando el código de conducta, les pedimos que lo reporte enviando un correo a organizadores@djangoquilla.com. Para mas detalles por favor vea nuestra Guia de Reporte.
+Si cree que alguien está violando el código de conducta, les pedimos que lo reporte enviando un correo a organizadores@pybaq.co. Para mas detalles por favor vea nuestra Guia de Reporte.
 
 * **Sea amigable y paciente.**
 * **Sea acogedor.** Nos esforzamos por ser una comunidad que acoge y da soporte a las personas de todos los orígenes e identidades. Esto incluye, pero no se limita a miembros de cualquier raza, etnia, cultura, nacionalidad, color, estatus de imigración, social y clase económica, nivel de educación, sexo, orientación sexual, identidad de género y de expresión, edad, talla, estatus familiar, político, religión, y habilidades mentales y físicas.


### PR DESCRIPTION
Reemplazado Django Barranquilla por Python Barranquilla.
Reemplazado dominio djangoquilla.com por pybaq.co